### PR TITLE
Call animateNextTransition only when activeKey has changed

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,9 +12,16 @@ const DEFAULT_TRANSITION = (
 class SwitchView extends React.Component {
   containerRef = React.createRef();
 
-  componentDidUpdate() {
-    this.containerRef.current &&
+  componentDidUpdate(prevProps) {
+    const { state: prevState } = prevProps.navigation;
+    const prevActiveKey = prevState.routes[prevState.index].key;
+    const { state } = this.props.navigation;
+    const activeKey = state.routes[state.index].key;
+
+    if (activeKey !== prevActiveKey) {
+      this.containerRef.current &&
       this.containerRef.current.animateNextTransition();
+    }
   }
 
   render() {

--- a/index.js
+++ b/index.js
@@ -18,8 +18,7 @@ class SwitchView extends React.Component {
     const { state } = this.props.navigation;
     const activeKey = state.routes[state.index].key;
 
-    if (activeKey !== prevActiveKey) {
-      this.containerRef.current &&
+    if (activeKey !== prevActiveKey && this.containerRef.current) {
       this.containerRef.current.animateNextTransition();
     }
   }


### PR DESCRIPTION
`animateNextTransition` was being called everytime `Switch` component received new props and that was messing up the transition effect on nested navigators. 

What we are doing now is comparing the previous route key with the current one to know if the switch route has changed, and if that’s the case, we call `animateNextTransition` 
