### PR TITLE
Added transitionBackgroundColor

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,11 @@ class SwitchView extends React.Component {
       <Transitioning.View
         ref={this.containerRef}
         transition={transition}
-        style={{ flex: 1 }}
+        style={{ 
+          flex: 1, 
+          backgroundColor: 
+            this.props.navigationConfig.transitionBackgroundColor || 'transparent' 
+        }}
       >
         <SceneView
           component={ChildComponent}


### PR DESCRIPTION
This pull request comes because of [this](https://github.com/react-navigation/animated-switch/issues/10) problem that I opened a few days ago, in practice I noticed that for any `Transition` with or without the `bottombar` there seems to be a default white color (with the bottombar is more visibile as you can see in the video attached with the issue). With this pull request you can assign a background color, so in this way there isn't strange white glitch