### PR TITLE
fix transition and transitionVierStyle does not work

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,7 +28,10 @@ const DEFAULT_TRANSITION = (
 );
 
 interface Props {
-  navigationConfig: { transition?: React.ReactNode };
+  navigationConfig: {
+    transition?: React.ReactNode,
+    transitionViewStyle?: ViewStyle,
+  };
   navigation: NavigationProp<NavigationState>;
   descriptors: { [key: string]: NavigationDescriptor };
   screenProps?: ScreenProps;
@@ -57,7 +60,8 @@ class AnimatedSwitchView extends React.Component<Props, {}> {
 
     const transition =
       (navigationConfig && navigationConfig.transition) || DEFAULT_TRANSITION;
-    const transitionViewStyle = navigationConfig && navigationConfig.transition;
+    const transitionViewStyle =
+      (navigationConfig && navigationConfig.transitionViewStyle) || null;
 
     return (
       <Transitioning.View

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,9 +28,8 @@ const DEFAULT_TRANSITION = (
 );
 
 interface Props {
-  navigation: NavigationProp<NavigationState> & {
-    navigationConfig: { transition?: React.ReactNode };
-  };
+  navigationConfig: { transition?: React.ReactNode };
+  navigation: NavigationProp<NavigationState>;
   descriptors: { [key: string]: NavigationDescriptor };
   screenProps?: ScreenProps;
 }
@@ -50,7 +49,8 @@ class AnimatedSwitchView extends React.Component<Props, {}> {
   }
 
   render() {
-    const { state, navigationConfig } = this.props.navigation;
+    const { navigationConfig } = this.props;
+    const { state } = this.props.navigation;
     const activeKey = state.routes[state.index].key;
     const descriptor = this.props.descriptors[activeKey];
     const ChildComponent = descriptor.getComponent();


### PR DESCRIPTION
Hi
I use this library for animated switch navigation, but transition and transitionViewStyle can't change.
So I fixed that, can't change transition default to custom and transitionVierStyle.

This bug is related to https://github.com/react-navigation/animated-switch/issues/20

thanks.