### PR TITLE
fix: fix typings for animated switch navigator.

### DIFF
--- a/types/@react-navigation/core.d.ts
+++ b/types/@react-navigation/core.d.ts
@@ -3,7 +3,9 @@ declare module '@react-navigation/core' {
   import { Transition } from 'react-native-reanimated';
   import {
     NavigationRouteConfigMap,
-    NavigationContainer,
+    NavigationNavigator,
+    NavigationProp,
+    NavigationState,
     SwitchNavigatorConfig,
     NavigationRouter,
   } from 'react-navigation';
@@ -18,7 +20,7 @@ declare module '@react-navigation/core' {
     StackView: React.ComponentType<any>,
     router: NavigationRouter<S, Options>,
     navigatorConfig?: {} | null
-  ): NavigationContainer;
+  ): NavigationNavigator<{}, NavigationProp<NavigationState>>;
 
   export function SwitchRouter(
     routeConfigMap: NavigationRouteConfigMap,


### PR DESCRIPTION
Fixes react-navigation/react-navigation/#6310 when using animated switch navigator instead of switch navigator. see react-navigation/react-navigation#6310