### PR TITLE
chore: Revert "Fixed location of types."

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/commonjs/index.js",
   "react-native": "lib/module/index.js",
   "module": "lib/module/index.js",
-  "types": "lib/typescript/index.d.ts",
+  "types": "lib/typescript/src/index.d.ts",
   "author": "",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
After the commit c717929 that includes the "example" folder, the location of the type definition file changed from `lib/typescript/index.d.ts` to `lib/typescript/src/index.d.ts`. This commit reverts 0bcd1f6 that changed the now correct types location.